### PR TITLE
Force UTF-8 encoding when reading HAR files

### DIFF
--- a/lib/har/archive.rb
+++ b/lib/har/archive.rb
@@ -9,7 +9,7 @@ module HAR
     def self.from_file(path_or_io)
       case path_or_io
       when String
-        from_string File.read(path_or_io), path_or_io
+        from_string File.read(path_or_io, :encoding => 'utf-8'), path_or_io
       when IO
         from_string path_or_io.read, path_or_io.to_s
       else


### PR DESCRIPTION
Would you consider making the HAR file encoding more explicit here?

http://www.softwareishard.com/blog/har-12-spec/ says that HAR archives must be in UTF-8 format. An approach like this proposed change could fix issues on operating systems in which the default file encoding is not UTF-8. For example, the default encoding on official Ruby docker images is US-ASCII, which creates problems when reading some HARs.

This line has been unchanged for 6 years, so changing it now could cause backwards compatibility issues in the general case. I am able to work around this problem locally by monkey-patching this class.