### PR TITLE
Do not use define_singleton_method for custom timings #7

### DIFF
--- a/lib/har/page_timings.rb
+++ b/lib/har/page_timings.rb
@@ -2,17 +2,16 @@ module HAR
   class PageTimings < SchemaType
     def initialize(input)
       super(input)
-      define_custom_timings(input)
+      @input = input
     end
 
-    private
+    def custom
+      @custom ||= begin
+        # TODO: move to `transform_keys` once ruby 2.0.0 support is dropped
+        custom_timings = Hash[@input.select { |key| key.start_with?('_') }
+                                    .map { |key, val| [key[1..-1], val] }]
 
-    # As defined by the HAR spec, custom timings must start with an underscore.
-    # To prevent collisions, the methods generated for those custom timings will
-    # also start with an underscore.
-    def define_custom_timings(input)
-      input.each do |key, value|
-        define_singleton_method(key) { value } if key.start_with?('_')
+        OpenStruct.new(custom_timings)
       end
     end
   end

--- a/spec/fixtures/hars/google.com.har
+++ b/spec/fixtures/hars/google.com.har
@@ -16,7 +16,7 @@
         "pageTimings":{
           "onContentLoad":90,
           "onLoad":245,
-          "_custom_example":123
+          "_customExample":123
         }
       }
     ],

--- a/spec/har/page_timings_spec.rb
+++ b/spec/har/page_timings_spec.rb
@@ -5,7 +5,7 @@ module HAR
     let(:timings) { Archive.from_file(google_path).pages.first.timings }
 
     it "defines methods for custom timings" do
-      timings._custom_example.should == 123
+      timings.custom.customExample.should == 123
     end
   end # PageTimings
 end # HAR


### PR DESCRIPTION
Turns out that singletons can't be dumped, which is used for
`#deep_clone` on the `Archive` class.