### PR TITLE
Fix entry_before filtering

### DIFF
--- a/lib/har/archive.rb
+++ b/lib/har/archive.rb
@@ -75,7 +75,7 @@ module HAR
     def entries_before(time)
       raise TypeError, "expected Time" unless time.is_a?(Time)
       entries.select do |entry|
-        return false unless entry.time
+        next(false) unless entry.time
         entry.started_date_time + entry.time / 1000.0 <= time
       end
     end

--- a/lib/har/page.rb
+++ b/lib/har/page.rb
@@ -15,7 +15,7 @@ module HAR
     def entries_before(time)
       raise TypeError, "expected Time" unless time.is_a?(Time)
       entries.select do |entry|
-        return false unless entry.time
+        next(false) unless entry.time
         entry.started_date_time + entry.time / 1000.0 <= time
       end
     end


### PR DESCRIPTION
This was a mistake that was overlooked. If an entry doesn't have a `time` attribute, we were accidentally returning out of the method instead of just passing by that entry in the `select` iteration.